### PR TITLE
Refactor (vectorize) some simpler functions

### DIFF
--- a/HAPPE_v2.m
+++ b/HAPPE_v2.m
@@ -867,9 +867,9 @@ for current_file = 1:length(FileNames)
             % WAVELETING QC METRICS
             disp('Evaluating wavelet thresholding...') ;
             % Root Mean Squared Error (RMSE):
-            RMSE_alldata = calcRMSE(preWavEEG, postWavEEG, 2) ;
+            RMSE_alldata = calcRMSE(preWavEEG, postWavEEG) ;
             % Mean Absolute Error (MAE):
-            MAE_alldata = calcMAE(preWavEEG, postWavEEG, 2) ;
+            MAE_alldata = calcMAE(preWavEEG, postWavEEG) ;
             % Signal to Noise Ratio (SNR) AND Peak Signal to Noise Ratio (PSNR):
             [SNR_alldata, PeakSNR_alldata] = calcSNR_PSNR(preWavEEG, postWavEEG, 2) ;
             % Cross Correlation Across Data and by Channel:
@@ -941,9 +941,9 @@ for current_file = 1:length(FileNames)
                 % Reshape EEG to channels x samples format
                 EEG2DICA = reshape(EEG.data, size(EEG.data,1), []) ;
                 % RMSE:
-                RMSE_alldata = calcRMSE(EEG2DICA, postWavEEG, 1) ;
+                RMSE_alldata = calcRMSE(EEG2DICA, postWavEEG) ;
                 % MAE:
-                MAE_alldata = calcMAE(EEG2DICA, postWavEEG, 1) ;
+                MAE_alldata = calcMAE(EEG2DICA, postWavEEG) ;
                 % SNR and PSNR:
                 [SNR_alldata, PeakSNR_alldata] = calcSNR_PSNR(EEG2DICA, postWavEEG, 1) ;
                 % Cross Correlation Across Data and by Channel:
@@ -960,9 +960,9 @@ for current_file = 1:length(FileNames)
                 EEG_preAR = reshape(EEG_preAR.data, size(EEG_preAR.data,1), []) ;
                 EEG_postAR = reshape(EEG_postAR.data, size(EEG_postAR.data, 1), []) ;
                 % RMSE:
-                RMSE_alldata = calcRMSE(EEG_postAR, EEG_preAR, 1) ;
+                RMSE_alldata = calcRMSE(EEG_postAR, EEG_preAR) ;
                 % MAE:
-                MAE_alldata = calcMAE(EEG_postAR, EEG_postAR, 1) ;
+                MAE_alldata = calcMAE(EEG_postAR, EEG_postAR) ;
                 % SNR AND PSNR:
                 [SNR_alldata, PeakSNR_alldata] = calcSNR_PSNR(EEG_postAR, EEG_preAR, 1) ;
                 % Cross Correlation across Data and by Channel:

--- a/scripts/calcMAE.m
+++ b/scripts/calcMAE.m
@@ -2,7 +2,7 @@
 %             particular processing step.
 %
 % Usage: 
-%   >> MAE = calcMAE(preEEG, postEEG, order)
+%   >> MAE = calcMAE(preEEG, postEEG)
 %
 % Inputs:
 %   preEEG  - EEG signal pre-processing step in channels x samples format
@@ -31,10 +31,4 @@
 
 function MAE = calcMAE(preEEG, postEEG)
     MAE = mean(mean(abs(preEEG - postEEG), 2));
-    
-%    % Step-by-step
-%    differences = preEEG - postEEG;
-%    absolute_differences = abs(differences);
-%    mean_absolute_differences = mean(absolute_differences, 2);
-%    MAE = mean(mean_absolute_differences);
 end

--- a/scripts/calcMAE.m
+++ b/scripts/calcMAE.m
@@ -7,8 +7,6 @@
 % Inputs:
 %   preEEG  - EEG signal pre-processing step in channels x samples format
 %   postEEG - EEG signal post-processing step in channels x samples format
-%   order   - The order in which to subtract the pre and post EEGs.
-%             {For 1, preEEG - postEEG; For 2, postEEG - preEEG} 
 %
 % Outputs:
 %   MAE - Mean Average Error across all channels and timepoints
@@ -31,17 +29,12 @@
 % You should have received a copy of the GNU General Public License
 % along with HAPPE. If not, see <https://www.gnu.org/licenses/>.
 
-function MAE = calcMAE(preEEG, postEEG, order)
-    MAE = zeros(size(preEEG, 1), 1) ;
-    for j = 1:size(preEEG, 1)
-        mae = 0 ;
-        for i = 1:length(preEEG)
-            if order == 2; mae = mae + abs(postEEG(j,i) - preEEG(j,i)) ;
-            elseif order == 1; mae = mae + abs(preEEG(j,i) - postEEG(j,i)) ;
-            end
-        end
-        [mae] = mae/length(preEEG) ;
-        MAE(j) = [mae] ;
-    end
-    MAE = mean(MAE) ;
+function MAE = calcMAE(preEEG, postEEG)
+    MAE = mean(mean(abs(preEEG - postEEG), 2));
+    
+%    % Step-by-step
+%    differences = preEEG - postEEG;
+%    absolute_differences = abs(differences);
+%    mean_absolute_differences = mean(absolute_differences, 2);
+%    MAE = mean(mean_absolute_differences);
 end

--- a/scripts/calcRMSE.m
+++ b/scripts/calcRMSE.m
@@ -7,8 +7,6 @@
 % Inputs:
 %   preEEG  - EEG signal pre-processing step in channels x samples format
 %   postEEG - EEG signal post-processing step in channels x samples format
-%   order   - The order in which to subtract the pre and post EEGs.
-%             {For 1, preEEG - postEEG; For 2, postEEG - preEEG} 
 %
 % Outputs:
 %   RMSE - Root Mean Squared Error over all channels and timepoints
@@ -31,17 +29,13 @@
 % You should have received a copy of the GNU General Public License
 % along with HAPPE. If not, see <https://www.gnu.org/licenses/>.
 
-function RMSE = calcRMSE(preEEG, postEEG, order)
-    RMSE = zeros(size(preEEG, 1), 1) ;
-    for j = 1:size(preEEG, 1)
-        mse = 0 ;
-        for i = 1:length(preEEG)
-            if order == 1; mse = mse + (preEEG(j,i) - postEEG(j,i))^2 ;
-            elseif order == 2; mse = mse + (postEEG(j,i) - preEEG(j,i))^2 ;
-            end
-        end
-        [rmse] = sqrt(mse/length(preEEG)) ;
-        RMSE(j) = [rmse] ;
-    end
-    RMSE = mean(RMSE) ;
+function RMSE = calcRMSE(preEEG, postEEG)
+    RMSE = mean(realsqrt(mean((preEEG - postEEG) .^ 2, 2)));
+    
+%    % Step-by-step
+%    differences = preEEG - postEEG;
+%    squared_errors = differences .^ 2;
+%    mean_squared_errors = mean(squared_errors, 2);
+%    root_mean_squared_errors = realsqrt(mean_squared_errors);
+%    RMSE = mean(root_mean_squared_errors);
 end

--- a/scripts/calcRMSE.m
+++ b/scripts/calcRMSE.m
@@ -2,7 +2,7 @@
 %              particular processing step.
 %
 % Usage: 
-%   >> RMSE = calcRMSE(preEEG, postEEG, order)
+%   >> RMSE = calcRMSE(preEEG, postEEG)
 %
 % Inputs:
 %   preEEG  - EEG signal pre-processing step in channels x samples format
@@ -31,11 +31,4 @@
 
 function RMSE = calcRMSE(preEEG, postEEG)
     RMSE = mean(realsqrt(mean((preEEG - postEEG) .^ 2, 2)));
-    
-%    % Step-by-step
-%    differences = preEEG - postEEG;
-%    squared_errors = differences .^ 2;
-%    mean_squared_errors = mean(squared_errors, 2);
-%    root_mean_squared_errors = realsqrt(mean_squared_errors);
-%    RMSE = mean(root_mean_squared_errors);
 end

--- a/scripts/calcSNR_PSNR.m
+++ b/scripts/calcSNR_PSNR.m
@@ -36,20 +36,13 @@
 
 function [SNR, PeakSNR] = calcSNR_PSNR(preEEG, postEEG, order)
     A_ = (order == 1) * preEEG + (order == 2) * postEEG;
-
-    % Calculate mean squared error per channel as intermediate variable:
-    squared_differences = (preEEG - postEEG) .^ 2;
-    MSE = mean(squared_differences, 2);
-
-    % Complete SNR and PSNR calculations:
-    DEN = sum(squared_differences, 2);
-    NUM = sum(A_ .^ 2, 2);
-    SNRs = 20 * log10(realsqrt(NUM) ./ realsqrt(DEN));
-    PeakSNRs = 20 * log10(max(A_, [], 2) ./ realsqrt(MSE));
-
-    % SNR over all channels and timepoints:
+    SE = (preEEG - postEEG) .^ 2;
+    
+    % SNRs and PeakSNRs per channel
+    SNRs = 20 * log10(realsqrt(sum(A_ .^ 2, 2)) ./ realsqrt(sum(SE, 2)));
+    PeakSNRs = 20 * log10(max(A_, [], 2) ./ realsqrt(mean(SE, 2)));
+    
+    % SNR and PeakSNR over all channels
     SNR = mean(SNRs);
-
-    % PSNR over all channels and timepoints:
     PeakSNR = mean(PeakSNRs);
 end

--- a/scripts/getStructureParameters.m
+++ b/scripts/getStructureParameters.m
@@ -1,9 +1,9 @@
-function p = getStructureParameters(mystruct, myfield, value)
-% Sets p to mystruct.myfield if it exists, other assigns it to value
-if  ~exist('value', 'var') && ~isfield(mystruct, myfield)
-    error('Either value of mystruct.myfield must exist');
-elseif exist('value', 'var') && ~isfield(mystruct, myfield) 
-    p = value;
-else
+function p = getStructureParameters(mystruct, myfield, default_value)
+% Returns mystruct.myfield if it exists, or default_value otherwise
+if isfield(mystruct, myfield)
     p = mystruct.(myfield);
+elseif exist("default_value", "var")
+    p = default_value;
+else
+    error("Either 'mystruct.myfield' or 'default_value' must exist");
 end


### PR DESCRIPTION
Some of the functions may be simplified using [vectorization](https://www.mathworks.com/help/matlab/matlab_prog/vectorization.html). The low-hanging fruits here are `calcMAE()`, `calcRMSE()`, and `calcSNR_PSNR()`. For `calcMAE()` and `calcRMSE()`, the function signatures may also be simplified, because the 'order' parameter is redundant.